### PR TITLE
Include LICENSE file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 autoexamples = false
 
 build = "bindings/rust/build.rs"
-include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
+include = ["LICENSE.md", "bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 
 [lib]
 path = "bindings/rust/lib.rs"


### PR DESCRIPTION
This is needed by the MIT license terms

```
❯ cargo package --list | grep LICENSE
LICENSE.md
```