### PR TITLE
fix(queries): re-add removed assignment operator

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -78,6 +78,8 @@
 (unary_expression
   operator: _ @operator)
 
+"=" @operator
+
 [
   "and"
   "not"


### PR DESCRIPTION
Fixup for #59: the `"="` node is not covered by `(*_expression)` patterns since it's an `(assignment_statement)`.