### PR TITLE
Fix the name of the included license file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = [
   "queries/*",
   "src/*",
   "tree-sitter.json",
-  "/LICENSE",
+  "/LICENSE.md",
 ]
 
 [lib]


### PR DESCRIPTION
PR #51 made sure the license file is shipped, however in https://github.com/tree-sitter-grammars/tree-sitter-lua/commit/4fbec840c34149b7d5fe10097c93a320ee4af053#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542 it got incorrectly renamed from LICENSE.md to LICENSE

Change it back so the license file gets picked up when running `cargo package`

```
$ cargo package --list | grep LICENSE

$ nvim Cargo.toml

$ cargo package --list --allow-dirty | grep LICENSE
LICENSE.md

$
```