### PR TITLE
Always include src/scanner.c in Swift package sources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,6 @@
 // swift-tools-version:5.3
 
-import Foundation
 import PackageDescription
-
-var sources = ["src/parser.c"]
-if FileManager.default.fileExists(atPath: "src/scanner.c") {
-    sources.append("src/scanner.c")
-}
 
 let package = Package(
     name: "TreeSitterLua",
@@ -21,7 +15,10 @@ let package = Package(
             name: "TreeSitterLua",
             dependencies: [],
             path: ".",
-            sources: sources,
+            sources: [
+                "src/parser.c",
+                "src/scanner.c",
+            ],
             resources: [
                 .copy("queries")
             ],


### PR DESCRIPTION
## Summary
- Stop probing for `src/scanner.c` with `FileManager` at manifest evaluation time.
- Always list `src/parser.c` and `src/scanner.c` in the Swift package `sources`.

## Why
Under Xcode / SwiftPM, `Package.swift` is often evaluated with a working directory where `FileManager.default.fileExists(atPath: "src/scanner.c")` returns false, so the external scanner is omitted and linking fails. Consumers work around this with local wrappers that hardcode both files. Listing the sources explicitly fixes the package for SPM clients.

## Test plan
- [ ] `swift build` / Xcode resolve includes scanner symbols from `src/scanner.c`
- [ ] Package still builds on platforms that previously worked


Made with [Cursor](https://cursor.com)